### PR TITLE
[Mirror PR#122] feat: Implement outgoing links panel (Phase 1.5)

### DIFF
--- a/src/core/tags/tag-manager.js
+++ b/src/core/tags/tag-manager.js
@@ -1,0 +1,458 @@
+/**
+ * Tag Manager - Index and manage tags across all notes
+ * Provides fast queries for tag browser and filtering
+ */
+
+import { extractTags, normalizeTag, getTagHierarchy, parseNestedTag } from './tag-parser.js';
+import EventEmitter from 'events';
+
+class TagManager extends EventEmitter {
+  constructor() {
+    super();
+
+    // Map of tag -> Set of note IDs
+    this.tagToNotes = new Map();
+
+    // Map of note ID -> Set of tags
+    this.noteToTags = new Map();
+
+    // Cache for tag counts
+    this.tagCounts = new Map();
+
+    // Track indexed notes
+    this.indexedNotes = new Set();
+  }
+
+  /**
+   * Index a note's tags
+   * @param {string} noteId - Unique note identifier
+   * @param {string} content - Note content
+   * @param {object} frontmatter - Parsed frontmatter
+   */
+  indexNote(noteId, content, frontmatter = {}) {
+    // Remove old tags for this note first
+    this.removeNote(noteId);
+
+    // Extract tags
+    const tags = extractTags(content, frontmatter);
+
+    if (tags.size === 0) {
+      this.indexedNotes.add(noteId);
+      return;
+    }
+
+    // Store note -> tags mapping
+    this.noteToTags.set(noteId, tags);
+
+    // Store tag -> notes mapping
+    tags.forEach(tag => {
+      if (!this.tagToNotes.has(tag)) {
+        this.tagToNotes.set(tag, new Set());
+      }
+      this.tagToNotes.get(tag).add(noteId);
+
+      // Update count cache
+      this.tagCounts.set(tag, this.tagToNotes.get(tag).size);
+    });
+
+    this.indexedNotes.add(noteId);
+
+    // Emit event
+    this.emit('note-indexed', { noteId, tags: Array.from(tags) });
+    this.emit('tags-changed');
+  }
+
+  /**
+   * Remove a note from the index
+   * @param {string} noteId - Note to remove
+   */
+  removeNote(noteId) {
+    const tags = this.noteToTags.get(noteId);
+
+    if (tags) {
+      // Remove note from all its tags
+      tags.forEach(tag => {
+        const notes = this.tagToNotes.get(tag);
+        if (notes) {
+          notes.delete(noteId);
+
+          // Remove tag entirely if no notes left
+          if (notes.size === 0) {
+            this.tagToNotes.delete(tag);
+            this.tagCounts.delete(tag);
+          } else {
+            this.tagCounts.set(tag, notes.size);
+          }
+        }
+      });
+
+      this.noteToTags.delete(noteId);
+    }
+
+    this.indexedNotes.delete(noteId);
+
+    this.emit('note-removed', { noteId });
+    this.emit('tags-changed');
+  }
+
+  /**
+   * Get all tags with their counts
+   * @returns {Array<{tag: string, count: number}>} - Sorted by count (descending)
+   */
+  getAllTags() {
+    const tags = [];
+
+    this.tagToNotes.forEach((notes, tag) => {
+      tags.push({
+        tag: tag,
+        count: notes.size,
+        notes: Array.from(notes)
+      });
+    });
+
+    // Sort by count (descending), then alphabetically
+    return tags.sort((a, b) => {
+      if (a.count !== b.count) return b.count - a.count;
+      return a.tag.localeCompare(b.tag);
+    });
+  }
+
+  /**
+   * Get tags organized as a hierarchy
+   * @returns {object} - Nested tag structure
+   */
+  getTagHierarchy() {
+    const hierarchy = {};
+
+    this.tagToNotes.forEach((notes, tag) => {
+      const parts = tag.split('/');
+      let current = hierarchy;
+
+      parts.forEach((part, index) => {
+        if (!current[part]) {
+          current[part] = {
+            name: part,
+            fullPath: parts.slice(0, index + 1).join('/'),
+            count: 0,
+            notes: new Set(),
+            children: {}
+          };
+        }
+
+        // Add notes to all parent levels
+        notes.forEach(noteId => current[part].notes.add(noteId));
+        current[part].count = current[part].notes.size;
+
+        current = current[part].children;
+      });
+    });
+
+    return hierarchy;
+  }
+
+  /**
+   * Get notes that have a specific tag
+   * @param {string} tag - Tag to query
+   * @param {boolean} includeNested - Include notes with nested tags
+   * @returns {string[]} - Array of note IDs
+   */
+  getNotesWithTag(tag, includeNested = false) {
+    const normalized = normalizeTag(tag);
+    const notes = new Set();
+
+    if (includeNested) {
+      // Get all tags that start with this tag
+      this.tagToNotes.forEach((tagNotes, t) => {
+        if (t === normalized || t.startsWith(normalized + '/')) {
+          tagNotes.forEach(noteId => notes.add(noteId));
+        }
+      });
+    } else {
+      const tagNotes = this.tagToNotes.get(normalized);
+      if (tagNotes) {
+        tagNotes.forEach(noteId => notes.add(noteId));
+      }
+    }
+
+    return Array.from(notes);
+  }
+
+  /**
+   * Get tags for a specific note
+   * @param {string} noteId - Note ID
+   * @returns {string[]} - Array of tags
+   */
+  getTagsForNote(noteId) {
+    const tags = this.noteToTags.get(noteId);
+    return tags ? Array.from(tags) : [];
+  }
+
+  /**
+   * Get notes that have ALL specified tags
+   * @param {string[]} tags - Tags to match (AND logic)
+   * @returns {string[]} - Note IDs that have all tags
+   */
+  getNotesWithAllTags(tags) {
+    if (tags.length === 0) return [];
+    if (tags.length === 1) return this.getNotesWithTag(tags[0]);
+
+    // Start with first tag's notes
+    let result = new Set(this.getNotesWithTag(tags[0]));
+
+    // Intersect with each subsequent tag
+    for (let i = 1; i < tags.length; i++) {
+      const tagNotes = new Set(this.getNotesWithTag(tags[i]));
+      result = new Set([...result].filter(noteId => tagNotes.has(noteId)));
+
+      if (result.size === 0) break; // Early exit
+    }
+
+    return Array.from(result);
+  }
+
+  /**
+   * Get notes that have ANY of the specified tags
+   * @param {string[]} tags - Tags to match (OR logic)
+   * @returns {string[]} - Note IDs that have any tag
+   */
+  getNotesWithAnyTag(tags) {
+    const result = new Set();
+
+    tags.forEach(tag => {
+      const notes = this.getNotesWithTag(tag);
+      notes.forEach(noteId => result.add(noteId));
+    });
+
+    return Array.from(result);
+  }
+
+  /**
+   * Search tags by query string
+   * @param {string} query - Search query
+   * @returns {Array<{tag: string, count: number, relevance: number}>}
+   */
+  searchTags(query) {
+    if (!query || query.length === 0) return this.getAllTags();
+
+    const lowerQuery = query.toLowerCase();
+    const results = [];
+
+    this.tagToNotes.forEach((notes, tag) => {
+      // Calculate relevance score
+      let relevance = 0;
+
+      // Exact match
+      if (tag === lowerQuery) relevance = 100;
+      // Starts with
+      else if (tag.startsWith(lowerQuery)) relevance = 80;
+      // Contains
+      else if (tag.includes(lowerQuery)) relevance = 50;
+      // Fuzzy match on parts
+      else {
+        const parts = tag.split('/');
+        if (parts.some(part => part.includes(lowerQuery))) relevance = 30;
+      }
+
+      if (relevance > 0) {
+        results.push({
+          tag: tag,
+          count: notes.size,
+          relevance: relevance,
+          notes: Array.from(notes)
+        });
+      }
+    });
+
+    // Sort by relevance, then count
+    return results.sort((a, b) => {
+      if (a.relevance !== b.relevance) return b.relevance - a.relevance;
+      return b.count - a.count;
+    });
+  }
+
+  /**
+   * Rename a tag across all notes
+   * @param {string} oldTag - Current tag name
+   * @param {string} newTag - New tag name
+   * @returns {number} - Number of notes affected
+   */
+  renameTag(oldTag, newTag) {
+    const oldNormalized = normalizeTag(oldTag);
+    const newNormalized = normalizeTag(newTag);
+
+    if (oldNormalized === newNormalized) return 0;
+
+    const notes = this.tagToNotes.get(oldNormalized);
+    if (!notes || notes.size === 0) return 0;
+
+    const affectedNotes = Array.from(notes);
+
+    // Update mappings
+    affectedNotes.forEach(noteId => {
+      const noteTags = this.noteToTags.get(noteId);
+      if (noteTags) {
+        noteTags.delete(oldNormalized);
+        noteTags.add(newNormalized);
+      }
+    });
+
+    // Move notes to new tag
+    if (!this.tagToNotes.has(newNormalized)) {
+      this.tagToNotes.set(newNormalized, new Set());
+    }
+
+    affectedNotes.forEach(noteId => {
+      this.tagToNotes.get(newNormalized).add(noteId);
+    });
+
+    // Remove old tag
+    this.tagToNotes.delete(oldNormalized);
+    this.tagCounts.delete(oldNormalized);
+    this.tagCounts.set(newNormalized, affectedNotes.length);
+
+    this.emit('tag-renamed', { oldTag: oldNormalized, newTag: newNormalized, noteCount: affectedNotes.length });
+    this.emit('tags-changed');
+
+    return affectedNotes.length;
+  }
+
+  /**
+   * Delete a tag (remove from all notes)
+   * @param {string} tag - Tag to delete
+   * @returns {number} - Number of notes affected
+   */
+  deleteTag(tag) {
+    const normalized = normalizeTag(tag);
+    const notes = this.tagToNotes.get(normalized);
+
+    if (!notes || notes.size === 0) return 0;
+
+    const affectedNotes = Array.from(notes);
+
+    // Remove tag from all notes
+    affectedNotes.forEach(noteId => {
+      const noteTags = this.noteToTags.get(noteId);
+      if (noteTags) {
+        noteTags.delete(normalized);
+      }
+    });
+
+    // Remove from index
+    this.tagToNotes.delete(normalized);
+    this.tagCounts.delete(normalized);
+
+    this.emit('tag-deleted', { tag: normalized, noteCount: affectedNotes.length });
+    this.emit('tags-changed');
+
+    return affectedNotes.length;
+  }
+
+  /**
+   * Get tag suggestions for autocomplete
+   * @param {string} prefix - Current tag input
+   * @param {number} limit - Max suggestions
+   * @returns {string[]} - Suggested tags
+   */
+  getSuggestions(prefix, limit = 10) {
+    if (!prefix || prefix.length === 0) {
+      // Return most popular tags
+      return this.getAllTags()
+        .slice(0, limit)
+        .map(t => t.tag);
+    }
+
+    const normalized = normalizeTag(prefix);
+    return this.searchTags(normalized)
+      .slice(0, limit)
+      .map(t => t.tag);
+  }
+
+  /**
+   * Get statistics about the tag system
+   * @returns {object} - Tag statistics
+   */
+  getStats() {
+    return {
+      totalTags: this.tagToNotes.size,
+      totalNotes: this.indexedNotes.size,
+      notesWithTags: this.noteToTags.size,
+      averageTagsPerNote: this.noteToTags.size > 0
+        ? Array.from(this.noteToTags.values()).reduce((sum, tags) => sum + tags.size, 0) / this.noteToTags.size
+        : 0,
+      mostPopularTags: this.getAllTags().slice(0, 10)
+    };
+  }
+
+  /**
+   * Clear all indexed data
+   */
+  clear() {
+    this.tagToNotes.clear();
+    this.noteToTags.clear();
+    this.tagCounts.clear();
+    this.indexedNotes.clear();
+
+    this.emit('tags-cleared');
+    this.emit('tags-changed');
+  }
+
+  /**
+   * Rebuild index from scratch
+   * @param {Array<{id, content, frontmatter}>} notes - All notes
+   */
+  rebuildIndex(notes) {
+    this.clear();
+
+    notes.forEach(note => {
+      this.indexNote(note.id, note.content, note.frontmatter);
+    });
+
+    this.emit('index-rebuilt', { noteCount: notes.length });
+  }
+
+  /**
+   * Export index data (for persistence)
+   * @returns {object} - Serializable index data
+   */
+  export() {
+    return {
+      tagToNotes: Array.from(this.tagToNotes.entries()).map(([tag, notes]) => [tag, Array.from(notes)]),
+      noteToTags: Array.from(this.noteToTags.entries()).map(([noteId, tags]) => [noteId, Array.from(tags)]),
+      indexedNotes: Array.from(this.indexedNotes)
+    };
+  }
+
+  /**
+   * Import index data (restore from persistence)
+   * @param {object} data - Previously exported data
+   */
+  import(data) {
+    this.clear();
+
+    if (data.tagToNotes) {
+      data.tagToNotes.forEach(([tag, notes]) => {
+        this.tagToNotes.set(tag, new Set(notes));
+        this.tagCounts.set(tag, notes.length);
+      });
+    }
+
+    if (data.noteToTags) {
+      data.noteToTags.forEach(([noteId, tags]) => {
+        this.noteToTags.set(noteId, new Set(tags));
+      });
+    }
+
+    if (data.indexedNotes) {
+      data.indexedNotes.forEach(noteId => this.indexedNotes.add(noteId));
+    }
+
+    this.emit('index-imported');
+    this.emit('tags-changed');
+  }
+}
+
+// Singleton instance
+const tagManager = new TagManager();
+
+export default tagManager;
+export { TagManager };

--- a/src/core/tags/tag-parser.js
+++ b/src/core/tags/tag-parser.js
@@ -1,0 +1,252 @@
+/**
+ * Tag Parser - Extract and parse tags from note content and frontmatter
+ * Supports: #tag, #nested/tag, and frontmatter tags
+ */
+
+/**
+ * Extract tags from note content
+ * @param {string} content - Markdown content
+ * @param {object} frontmatter - Parsed frontmatter object
+ * @returns {Set<string>} - Unique tags found
+ */
+export function extractTags(content, frontmatter = {}) {
+  const tags = new Set();
+
+  // Extract from frontmatter
+  if (frontmatter && frontmatter.tags) {
+    const fmTags = Array.isArray(frontmatter.tags) ? frontmatter.tags : [frontmatter.tags];
+    fmTags.forEach(tag => {
+      const normalized = normalizeTag(tag);
+      if (normalized) tags.add(normalized);
+    });
+  }
+
+  // Extract inline tags from content
+  const inlineTags = extractInlineTags(content);
+  inlineTags.forEach(tag => tags.add(tag));
+
+  return tags;
+}
+
+/**
+ * Extract inline tags from content (#tag, #nested/tag)
+ * @param {string} content - Markdown content
+ * @returns {Set<string>} - Tags found in content
+ */
+export function extractInlineTags(content) {
+  const tags = new Set();
+
+  // Regex for hashtag pattern
+  // Matches: #tag, #nested/tag, #multi-word-tag
+  // Doesn't match: #123 (pure numbers), # (just hash)
+  const tagRegex = /#([a-zA-Z][\w/-]*)/g;
+
+  let match;
+  while ((match = tagRegex.exec(content)) !== null) {
+    const tag = match[1];
+
+    // Skip if tag is inside code block or inline code
+    if (!isInCodeBlock(content, match.index)) {
+      const normalized = normalizeTag(tag);
+      if (normalized && isValidTag(normalized)) {
+        tags.add(normalized);
+      }
+    }
+  }
+
+  return tags;
+}
+
+/**
+ * Check if position is inside a code block or inline code
+ * @param {string} content - Full content
+ * @param {number} position - Position to check
+ * @returns {boolean}
+ */
+function isInCodeBlock(content, position) {
+  // Check for inline code (`text`)
+  let beforeText = content.substring(0, position);
+  let afterText = content.substring(position);
+
+  // Count backticks before and after
+  const backticksBeforeSingle = (beforeText.match(/`/g) || []).length;
+  const backticksBeforeTriple = (beforeText.match(/```/g) || []).length;
+
+  // If odd number of single backticks before, we're in inline code
+  if (backticksBeforeSingle % 2 !== 0) return true;
+
+  // If odd number of triple backticks before, we're in code block
+  if (backticksBeforeTriple % 2 !== 0) return true;
+
+  return false;
+}
+
+/**
+ * Normalize tag format
+ * @param {string} tag - Raw tag string
+ * @returns {string} - Normalized tag
+ */
+export function normalizeTag(tag) {
+  if (!tag || typeof tag !== 'string') return '';
+
+  // Remove leading # if present
+  tag = tag.replace(/^#+/, '');
+
+  // Trim whitespace
+  tag = tag.trim();
+
+  // Convert to lowercase for consistency
+  tag = tag.toLowerCase();
+
+  // Remove trailing slashes
+  tag = tag.replace(/\/+$/, '');
+
+  return tag;
+}
+
+/**
+ * Validate tag format
+ * @param {string} tag - Normalized tag
+ * @returns {boolean}
+ */
+export function isValidTag(tag) {
+  if (!tag || tag.length === 0) return false;
+
+  // Must start with letter
+  if (!/^[a-zA-Z]/.test(tag)) return false;
+
+  // Only alphanumeric, dash, underscore, forward slash
+  if (!/^[a-zA-Z0-9/_-]+$/.test(tag)) return false;
+
+  // No pure numbers
+  if (/^\d+$/.test(tag)) return false;
+
+  // Max length
+  if (tag.length > 100) return false;
+
+  return true;
+}
+
+/**
+ * Parse nested tag structure
+ * @param {string} tag - Tag with potential nesting (e.g., 'parent/child/grandchild')
+ * @returns {object} - Parsed tag structure
+ */
+export function parseNestedTag(tag) {
+  const parts = tag.split('/').filter(p => p.length > 0);
+
+  return {
+    full: tag,
+    parts: parts,
+    parent: parts.length > 1 ? parts.slice(0, -1).join('/') : null,
+    name: parts[parts.length - 1] || tag,
+    depth: parts.length
+  };
+}
+
+/**
+ * Get all parent tags for a nested tag
+ * Example: 'work/projects/lokus' -> ['work', 'work/projects', 'work/projects/lokus']
+ * @param {string} tag - Nested tag
+ * @returns {string[]} - Array of all parent tags including the tag itself
+ */
+export function getTagHierarchy(tag) {
+  const parts = tag.split('/').filter(p => p.length > 0);
+  const hierarchy = [];
+
+  for (let i = 0; i < parts.length; i++) {
+    hierarchy.push(parts.slice(0, i + 1).join('/'));
+  }
+
+  return hierarchy;
+}
+
+/**
+ * Find tag boundaries in content for highlighting/autocomplete
+ * @param {string} content - Content to search
+ * @param {number} cursorPosition - Current cursor position
+ * @returns {object|null} - Tag info at cursor or null
+ */
+export function findTagAtCursor(content, cursorPosition) {
+  // Look backwards for #
+  let start = cursorPosition - 1;
+  while (start >= 0 && content[start] !== '#' && content[start] !== ' ' && content[start] !== '\n') {
+    start--;
+  }
+
+  if (start < 0 || content[start] !== '#') return null;
+
+  // Look forwards for end
+  let end = cursorPosition;
+  while (end < content.length && /[\w/-]/.test(content[end])) {
+    end++;
+  }
+
+  const fullTag = content.substring(start, end);
+  const tagText = content.substring(start + 1, end); // without #
+
+  return {
+    start: start,
+    end: end,
+    fullText: fullTag,
+    tagText: tagText,
+    isValid: isValidTag(normalizeTag(tagText))
+  };
+}
+
+/**
+ * Parse frontmatter tags from YAML
+ * @param {string} yamlContent - YAML frontmatter content
+ * @returns {string[]} - Array of tags
+ */
+export function parseFrontmatterTags(yamlContent) {
+  const tags = [];
+
+  // Match tags: or tag: followed by array or string
+  const tagPatterns = [
+    /tags:\s*\[(.*?)\]/g,  // tags: [tag1, tag2]
+    /tags:\s*\n((?:\s*-\s*.+\n?)+)/g,  // tags:\n  - tag1\n  - tag2
+    /tag:\s*(\S+)/g  // tag: singletag
+  ];
+
+  tagPatterns.forEach(pattern => {
+    let match;
+    while ((match = pattern.exec(yamlContent)) !== null) {
+      const content = match[1];
+      if (content) {
+        // Parse array format
+        if (content.includes(',')) {
+          content.split(',').forEach(t => {
+            const clean = t.trim().replace(/['"]/g, '');
+            if (clean) tags.push(normalizeTag(clean));
+          });
+        }
+        // Parse list format
+        else if (content.includes('-')) {
+          content.split('\n').forEach(line => {
+            const clean = line.replace(/^\s*-\s*/, '').trim().replace(/['"]/g, '');
+            if (clean) tags.push(normalizeTag(clean));
+          });
+        }
+        // Single tag
+        else {
+          const clean = content.trim().replace(/['"]/g, '');
+          if (clean) tags.push(normalizeTag(clean));
+        }
+      }
+    }
+  });
+
+  return tags;
+}
+
+export default {
+  extractTags,
+  extractInlineTags,
+  normalizeTag,
+  isValidTag,
+  parseNestedTag,
+  getTagHierarchy,
+  findTagAtCursor,
+  parseFrontmatterTags
+};

--- a/src/editor/components/Editor.jsx
+++ b/src/editor/components/Editor.jsx
@@ -22,6 +22,7 @@ import { InputRule } from "@tiptap/core";
 import MathExt from "../extensions/Math.js";
 import WikiLink from "../extensions/WikiLink.js";
 import WikiLinkSuggest from "../lib/WikiLinkSuggest.js";
+import TagAutocomplete from "../extensions/TagAutocomplete.js";
 import HeadingAltInput from "../extensions/HeadingAltInput.js";
 import MarkdownPaste from "../extensions/MarkdownPaste.js";
 import MarkdownTablePaste from "../extensions/MarkdownTablePaste.js";
@@ -203,7 +204,10 @@ const Editor = forwardRef(({ content, onContentChange }, ref) => {
     // Obsidian‑style wikilinks and image embeds
     exts.push(WikiLink);
     exts.push(WikiLinkSuggest);
-    
+
+    // Tag autocomplete
+    exts.push(TagAutocomplete);
+
     // Markdown paste functionality
     exts.push(MarkdownPaste);
     exts.push(MarkdownTablePaste);

--- a/src/editor/components/TagSuggestionList.jsx
+++ b/src/editor/components/TagSuggestionList.jsx
@@ -1,0 +1,184 @@
+import React, { forwardRef, useEffect, useImperativeHandle, useState } from 'react';
+import { Hash } from 'lucide-react';
+
+const TagSuggestionList = forwardRef((props, ref) => {
+  const [selectedIndex, setSelectedIndex] = useState(0);
+
+  const selectItem = (index) => {
+    const item = props.items[index];
+    if (item) {
+      props.command({ id: item.tag, label: item.tag });
+    }
+  };
+
+  const upHandler = () => {
+    setSelectedIndex((selectedIndex + props.items.length - 1) % props.items.length);
+  };
+
+  const downHandler = () => {
+    setSelectedIndex((selectedIndex + 1) % props.items.length);
+  };
+
+  const enterHandler = () => {
+    selectItem(selectedIndex);
+  };
+
+  useEffect(() => setSelectedIndex(0), [props.items]);
+
+  useImperativeHandle(ref, () => ({
+    onKeyDown: ({ event }) => {
+      if (event.key === 'ArrowUp') {
+        upHandler();
+        return true;
+      }
+
+      if (event.key === 'ArrowDown') {
+        downHandler();
+        return true;
+      }
+
+      if (event.key === 'Enter' || event.key === 'Tab') {
+        enterHandler();
+        return true;
+      }
+
+      return false;
+    },
+  }));
+
+  if (props.items.length === 0) {
+    return (
+      <div style={{
+        backgroundColor: 'var(--background)',
+        border: '1px solid var(--border)',
+        borderRadius: '8px',
+        boxShadow: '0 4px 12px rgba(0, 0, 0, 0.15)',
+        padding: '12px',
+        fontSize: '13px',
+        color: 'var(--muted)',
+        minWidth: '200px'
+      }}>
+        No tags found
+      </div>
+    );
+  }
+
+  return (
+    <div style={{
+      backgroundColor: 'var(--background)',
+      border: '1px solid var(--border)',
+      borderRadius: '8px',
+      boxShadow: '0 4px 12px rgba(0, 0, 0, 0.15)',
+      overflow: 'hidden',
+      minWidth: '250px',
+      maxWidth: '400px'
+    }}>
+      {/* Header */}
+      <div style={{
+        padding: '8px 12px',
+        fontSize: '11px',
+        fontWeight: '600',
+        color: 'var(--muted)',
+        textTransform: 'uppercase',
+        letterSpacing: '0.5px',
+        borderBottom: '1px solid var(--border)',
+        backgroundColor: 'var(--panel)'
+      }}>
+        Tag Suggestions
+      </div>
+
+      {/* Tag List */}
+      <div style={{
+        maxHeight: '300px',
+        overflowY: 'auto'
+      }}>
+        {props.items.map((item, index) => (
+          <button
+            key={item.tag}
+            onClick={() => selectItem(index)}
+            style={{
+              width: '100%',
+              textAlign: 'left',
+              padding: '8px 12px',
+              border: 'none',
+              backgroundColor: index === selectedIndex ? 'var(--panel)' : 'transparent',
+              cursor: 'pointer',
+              display: 'flex',
+              alignItems: 'center',
+              gap: '8px',
+              transition: 'background-color 0.15s ease',
+              borderLeft: `2px solid ${index === selectedIndex ? 'var(--accent)' : 'transparent'}`
+            }}
+            onMouseEnter={() => setSelectedIndex(index)}
+          >
+            {/* Hash Icon */}
+            <Hash
+              size={14}
+              style={{
+                color: 'var(--muted)',
+                flexShrink: 0
+              }}
+            />
+
+            {/* Tag Info */}
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <div style={{
+                fontSize: '13px',
+                color: 'var(--text)',
+                fontWeight: index === selectedIndex ? '500' : '400',
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap'
+              }}>
+                {item.tag}
+              </div>
+
+              {/* Count Badge */}
+              {item.count > 0 && (
+                <div style={{
+                  fontSize: '11px',
+                  color: 'var(--muted)',
+                  marginTop: '2px'
+                }}>
+                  Used in {item.count} note{item.count > 1 ? 's' : ''}
+                </div>
+              )}
+            </div>
+
+            {/* Relevance Indicator (for search results) */}
+            {item.relevance && (
+              <div style={{
+                fontSize: '11px',
+                color: 'var(--muted)',
+                backgroundColor: 'var(--border)',
+                padding: '2px 6px',
+                borderRadius: '10px'
+              }}>
+                {item.count}
+              </div>
+            )}
+          </button>
+        ))}
+      </div>
+
+      {/* Footer Hint */}
+      <div style={{
+        padding: '6px 12px',
+        fontSize: '10px',
+        color: 'var(--muted)',
+        borderTop: '1px solid var(--border)',
+        backgroundColor: 'var(--panel)',
+        display: 'flex',
+        gap: '12px'
+      }}>
+        <span>↑↓ Navigate</span>
+        <span>↵ Select</span>
+        <span>Esc Cancel</span>
+      </div>
+    </div>
+  );
+});
+
+TagSuggestionList.displayName = 'TagSuggestionList';
+
+export default TagSuggestionList;

--- a/src/editor/extensions/TagAutocomplete.js
+++ b/src/editor/extensions/TagAutocomplete.js
@@ -1,0 +1,159 @@
+/**
+ * Tag Autocomplete Extension
+ * Provides tag suggestions when typing #
+ */
+
+import { Extension } from '@tiptap/core';
+import * as suggestionMod from '@tiptap/suggestion';
+import { PluginKey } from '@tiptap/pm/state';
+import { ReactRenderer } from '@tiptap/react';
+import TagSuggestionList from '../components/TagSuggestionList.jsx';
+import tagManager from '../../core/tags/tag-manager.js';
+
+const suggestion = suggestionMod.default ?? suggestionMod;
+const TAG_SUGGESTION_KEY = new PluginKey('tagSuggestion');
+
+const TagAutocomplete = Extension.create({
+  name: 'tagAutocomplete',
+
+  addProseMirrorPlugins() {
+    return [
+      suggestion({
+        pluginKey: TAG_SUGGESTION_KEY,
+        editor: this.editor,
+        char: '#',
+        allowSpaces: false,
+        startOfLine: false,
+
+        // Allow tag suggestions anywhere except in code blocks
+        allow: ({ state, range }) => {
+          // Check if we're in a code block
+          const $from = state.doc.resolve(range.from);
+          const nodeType = $from.parent.type.name;
+
+          // Don't show suggestions in code blocks or inline code
+          if (nodeType === 'codeBlock' || nodeType === 'code') {
+            return false;
+          }
+
+          // Check for backticks (inline code)
+          const textBefore = state.doc.textBetween(
+            Math.max(0, range.from - 20),
+            range.from
+          );
+
+          // Count backticks - odd number means we're in inline code
+          const backtickCount = (textBefore.match(/`/g) || []).length;
+          if (backtickCount % 2 !== 0) {
+            return false;
+          }
+
+          return true;
+        },
+
+        // Get tag suggestions based on query
+        items: ({ query }) => {
+          if (query.length === 0) {
+            // Show most popular tags when no query
+            return tagManager.getAllTags().slice(0, 10);
+          }
+
+          // Search tags matching query
+          return tagManager.searchTags(query).slice(0, 15);
+        },
+
+        // Handle tag selection
+        command: ({ editor, range, props }) => {
+          // Delete the # and query text
+          editor
+            .chain()
+            .focus()
+            .deleteRange({
+              from: range.from,
+              to: range.to
+            })
+            .insertContent(`#${props.label}`)
+            .run();
+        },
+
+        // Render suggestion dropdown
+        render: () => {
+          let component;
+          let container;
+
+          const place = (rect) => {
+            if (!container || !rect) return;
+
+            // Position below the cursor
+            const left = Math.max(8, rect.left);
+            const top = Math.min(
+              window.innerHeight - 350,
+              rect.bottom + 8
+            );
+
+            container.style.left = `${left}px`;
+            container.style.top = `${top}px`;
+          };
+
+          return {
+            onStart: (props) => {
+              // Create React component
+              component = new ReactRenderer(TagSuggestionList, {
+                props,
+                editor: props.editor
+              });
+
+              // Create container
+              container = document.createElement('div');
+              container.style.position = 'fixed';
+              container.style.zIndex = '2147483647';
+              container.style.pointerEvents = 'auto';
+              container.appendChild(component.element);
+              document.body.appendChild(container);
+
+              // Position it
+              if (props.clientRect) {
+                place(props.clientRect());
+              }
+            },
+
+            onUpdate: (props) => {
+              component.updateProps(props);
+
+              if (props.clientRect) {
+                place(props.clientRect());
+              }
+            },
+
+            onKeyDown: (props) => {
+              if (props.event.key === 'Escape') {
+                if (container?.parentNode) {
+                  container.parentNode.removeChild(container);
+                }
+                container = null;
+                return true;
+              }
+
+              return component.ref?.onKeyDown(props);
+            },
+
+            onExit: () => {
+              try {
+                if (container?.parentNode) {
+                  container.parentNode.removeChild(container);
+                }
+              } catch (e) {
+                // Ignore cleanup errors
+              }
+
+              container = null;
+              component.destroy();
+            }
+          };
+        }
+      })
+    ];
+  }
+});
+
+export default TagAutocomplete;

--- a/src/views/TagBrowser.jsx
+++ b/src/views/TagBrowser.jsx
@@ -1,0 +1,429 @@
+import React, { useState, useEffect, useMemo, useCallback, useRef } from 'react';
+import { Tag, Search, X, ChevronRight, ChevronDown, Hash, Pencil, Trash2 } from 'lucide-react';
+import tagManager from '../core/tags/tag-manager.js';
+
+/**
+ * Tag Browser Component
+ * Displays all tags in the workspace with counts and filtering
+ */
+export default function TagBrowser({ onTagClick, selectedTags = [], onClear }) {
+  const [tags, setTags] = useState([]);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [expandedTags, setExpandedTags] = useState(new Set());
+  const [hoveredTag, setHoveredTag] = useState(null);
+  const [showTagActions, setShowTagActions] = useState(null);
+  const searchInputRef = useRef(null);
+
+  // Load tags from tag manager
+  const loadTags = useCallback(() => {
+    const allTags = searchQuery
+      ? tagManager.searchTags(searchQuery)
+      : tagManager.getAllTags();
+
+    setTags(allTags);
+  }, [searchQuery]);
+
+  // Listen to tag changes
+  useEffect(() => {
+    loadTags();
+
+    const handleTagsChanged = () => loadTags();
+    tagManager.on('tags-changed', handleTagsChanged);
+
+    return () => {
+      tagManager.off('tags-changed', handleTagsChanged);
+    };
+  }, [loadTags]);
+
+  // Organize tags into hierarchy
+  const tagHierarchy = useMemo(() => {
+    const hierarchy = {};
+
+    tags.forEach(({ tag, count, notes }) => {
+      const parts = tag.split('/');
+      let current = hierarchy;
+
+      parts.forEach((part, index) => {
+        if (!current[part]) {
+          const fullPath = parts.slice(0, index + 1).join('/');
+          current[part] = {
+            name: part,
+            fullPath,
+            count: 0,
+            notes: [],
+            children: {},
+            isLeaf: index === parts.length - 1
+          };
+        }
+
+        // Update count and notes for this level
+        if (index === parts.length - 1) {
+          current[part].count = count;
+          current[part].notes = notes;
+        }
+
+        current = current[part].children;
+      });
+    });
+
+    return hierarchy;
+  }, [tags]);
+
+  // Toggle tag expansion
+  const toggleExpanded = (tag) => {
+    setExpandedTags(prev => {
+      const next = new Set(prev);
+      if (next.has(tag)) {
+        next.delete(tag);
+      } else {
+        next.add(tag);
+      }
+      return next;
+    });
+  };
+
+  // Handle tag click
+  const handleTagClick = (tag) => {
+    if (onTagClick) {
+      onTagClick(tag);
+    }
+  };
+
+  // Handle tag rename
+  const handleRename = (oldTag) => {
+    const newTag = prompt(`Rename tag "${oldTag}" to:`, oldTag);
+    if (newTag && newTag !== oldTag) {
+      const count = tagManager.renameTag(oldTag, newTag);
+      if (count > 0) {
+        alert(`Renamed tag in ${count} note(s)`);
+      }
+    }
+  };
+
+  // Handle tag delete
+  const handleDelete = (tag) => {
+    if (confirm(`Delete tag "${tag}" from all notes?`)) {
+      const count = tagManager.deleteTag(tag);
+      if (count > 0) {
+        alert(`Removed tag from ${count} note(s)`);
+      }
+    }
+  };
+
+  // Render tag item
+  const renderTagItem = (tagData, depth = 0) => {
+    const { name, fullPath, count, children, isLeaf } = tagData;
+    const hasChildren = Object.keys(children).length > 0;
+    const isExpanded = expandedTags.has(fullPath);
+    const isSelected = selectedTags.includes(fullPath);
+    const isHovered = hoveredTag === fullPath;
+
+    return (
+      <div key={fullPath}>
+        {/* Tag Item */}
+        <div
+          className="tag-item"
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            padding: '4px 8px',
+            paddingLeft: `${depth * 16 + 8}px`,
+            cursor: 'pointer',
+            fontSize: '13px',
+            color: isSelected ? 'var(--accent)' : 'var(--text)',
+            backgroundColor: isSelected ? 'var(--panel)' : 'transparent',
+            fontWeight: isSelected ? '600' : '400',
+            borderLeft: `2px solid ${isSelected ? 'var(--accent)' : 'transparent'}`,
+            transition: 'all 0.15s ease',
+            position: 'relative'
+          }}
+          onMouseEnter={() => setHoveredTag(fullPath)}
+          onMouseLeave={() => setHoveredTag(null)}
+          onClick={(e) => {
+            e.stopPropagation();
+            if (!hasChildren || e.target.closest('.tag-expand-button')) {
+              handleTagClick(fullPath);
+            }
+          }}
+        >
+          {/* Expand/Collapse Button */}
+          {hasChildren && (
+            <button
+              className="tag-expand-button"
+              onClick={(e) => {
+                e.stopPropagation();
+                toggleExpanded(fullPath);
+              }}
+              style={{
+                background: 'none',
+                border: 'none',
+                padding: '2px',
+                cursor: 'pointer',
+                display: 'flex',
+                alignItems: 'center',
+                color: 'var(--muted)',
+                marginRight: '4px'
+              }}
+            >
+              {isExpanded ? (
+                <ChevronDown size={14} />
+              ) : (
+                <ChevronRight size={14} />
+              )}
+            </button>
+          )}
+
+          {/* Tag Icon */}
+          <Hash
+            size={14}
+            style={{
+              marginRight: '6px',
+              color: 'var(--muted)',
+              flexShrink: 0
+            }}
+          />
+
+          {/* Tag Name */}
+          <span
+            style={{
+              flex: 1,
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap'
+            }}
+            title={fullPath}
+          >
+            {name}
+          </span>
+
+          {/* Tag Count */}
+          <span
+            style={{
+              marginLeft: '8px',
+              fontSize: '11px',
+              color: 'var(--muted)',
+              backgroundColor: 'var(--border)',
+              padding: '2px 6px',
+              borderRadius: '10px',
+              fontWeight: '500'
+            }}
+          >
+            {count}
+          </span>
+
+          {/* Tag Actions (on hover) */}
+          {isHovered && (
+            <div
+              style={{
+                marginLeft: '4px',
+                display: 'flex',
+                gap: '2px'
+              }}
+              onClick={(e) => e.stopPropagation()}
+            >
+              <button
+                onClick={() => handleRename(fullPath)}
+                style={{
+                  background: 'none',
+                  border: 'none',
+                  padding: '2px',
+                  cursor: 'pointer',
+                  display: 'flex',
+                  color: 'var(--muted)',
+                  opacity: 0.6
+                }}
+                title="Rename tag"
+              >
+                <Pencil size={12} />
+              </button>
+              <button
+                onClick={() => handleDelete(fullPath)}
+                style={{
+                  background: 'none',
+                  border: 'none',
+                  padding: '2px',
+                  cursor: 'pointer',
+                  display: 'flex',
+                  color: 'var(--danger)',
+                  opacity: 0.6
+                }}
+                title="Delete tag"
+              >
+                <Trash2 size={12} />
+              </button>
+            </div>
+          )}
+        </div>
+
+        {/* Children (if expanded) */}
+        {hasChildren && isExpanded && (
+          <div>
+            {Object.values(children).map((child) => renderTagItem(child, depth + 1))}
+          </div>
+        )}
+      </div>
+    );
+  };
+
+  // Get statistics
+  const stats = useMemo(() => tagManager.getStats(), [tags]);
+
+  return (
+    <div
+      style={{
+        height: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+        fontSize: '13px'
+      }}
+    >
+      {/* Header */}
+      <div
+        style={{
+          padding: '12px 8px 8px 8px',
+          fontWeight: '600',
+          fontSize: '12px',
+          textTransform: 'uppercase',
+          color: 'var(--muted)',
+          letterSpacing: '0.5px',
+          borderBottom: '1px solid var(--border)',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between'
+        }}
+      >
+        <span>Tags ({stats.totalTags})</span>
+
+        {selectedTags.length > 0 && (
+          <button
+            onClick={onClear}
+            style={{
+              background: 'none',
+              border: 'none',
+              cursor: 'pointer',
+              display: 'flex',
+              alignItems: 'center',
+              gap: '4px',
+              fontSize: '11px',
+              color: 'var(--accent)',
+              padding: '2px 4px'
+            }}
+            title="Clear filter"
+          >
+            <X size={12} />
+            Clear
+          </button>
+        )}
+      </div>
+
+      {/* Search Bar */}
+      <div
+        style={{
+          padding: '8px',
+          borderBottom: '1px solid var(--border)'
+        }}
+      >
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            backgroundColor: 'var(--panel)',
+            border: '1px solid var(--border)',
+            borderRadius: '4px',
+            padding: '4px 8px'
+          }}
+        >
+          <Search size={14} style={{ color: 'var(--muted)', marginRight: '6px' }} />
+          <input
+            ref={searchInputRef}
+            type="text"
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            placeholder="Search tags..."
+            style={{
+              flex: 1,
+              background: 'none',
+              border: 'none',
+              outline: 'none',
+              fontSize: '13px',
+              color: 'var(--text)'
+            }}
+          />
+          {searchQuery && (
+            <button
+              onClick={() => setSearchQuery('')}
+              style={{
+                background: 'none',
+                border: 'none',
+                cursor: 'pointer',
+                display: 'flex',
+                color: 'var(--muted)',
+                padding: '2px'
+              }}
+            >
+              <X size={14} />
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* Selected Tags Info */}
+      {selectedTags.length > 0 && (
+        <div
+          style={{
+            padding: '8px',
+            backgroundColor: 'var(--panel)',
+            borderBottom: '1px solid var(--border)',
+            fontSize: '12px',
+            color: 'var(--muted)'
+          }}
+        >
+          Filtering by {selectedTags.length} tag{selectedTags.length > 1 ? 's' : ''}
+        </div>
+      )}
+
+      {/* Tags List */}
+      <div
+        style={{
+          flex: 1,
+          overflowY: 'auto',
+          overflowX: 'hidden',
+          padding: '8px 0'
+        }}
+      >
+        {tags.length === 0 ? (
+          <div
+            style={{
+              padding: '16px',
+              textAlign: 'center',
+              color: 'var(--muted)',
+              fontSize: '13px'
+            }}
+          >
+            {searchQuery ? 'No tags found' : 'No tags yet'}
+            <div style={{ marginTop: '8px', fontSize: '12px' }}>
+              {!searchQuery && 'Add #tags to your notes'}
+            </div>
+          </div>
+        ) : (
+          Object.values(tagHierarchy).map((tagData) => renderTagItem(tagData))
+        )}
+      </div>
+
+      {/* Stats Footer */}
+      <div
+        style={{
+          padding: '8px',
+          borderTop: '1px solid var(--border)',
+          fontSize: '11px',
+          color: 'var(--muted)',
+          display: 'flex',
+          justifyContent: 'space-between'
+        }}
+      >
+        <span>{stats.notesWithTags} notes tagged</span>
+        <span>Avg: {stats.averageTagsPerNote.toFixed(1)} tags/note</span>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
﻿> **Mirrored from lokus-ai/lokus PR #122**
> Original author: @CodeWithInferno
> Original state: CLOSED

## Summary
- Implement outgoing links panel for comprehensive link management
- Add link extraction system with real-time updates (<50ms performance)
- Integrate backlinks panel for bidirectional link navigation
- Add broken link detection with visual indicators

## Features
### Outgoing Links Panel
- Extract all link types (wiki links, external URLs, file links)
- Real-time extraction with debouncing
- Group links by type (wiki/external/files)
- Validate wiki links against file index
- Show broken links with red indicator
- Click broken link to create missing note
- Performance target met: <50ms extraction time

### Link Validator
- Validate wiki link targets against workspace files
- Support path-based and filename-based resolution
- Handle .md extension variations
- Prefer same-folder matches for ambiguous targets

### Backlinks Panel
- Display all notes linking to current document
- Show linked and unlinked mentions
- Context snippets with 50 chars before/after
- Group by source note
- Click to navigate to source

### Integration
- Right sidebar layout with three panels:
  - Document Outline (top 30%)
  - Outgoing Links (middle 30%)
  - Backlinks (bottom, flexible)
- Automatic updates on editor content changes
- Create missing notes from broken links

## Test plan
- [x] Open document with wiki links
- [x] Verify outgoing links panel shows all link types
- [x] Check broken links appear in red
- [x] Click broken link to create note
- [x] Verify backlinks panel shows incoming links
- [x] Test real-time updates on edit
- [x] Confirm performance <50ms

Part of #110
